### PR TITLE
DM-92 previous season transactions

### DIFF
--- a/frontend/src/components/SelectSeasonDropDown.tsx
+++ b/frontend/src/components/SelectSeasonDropDown.tsx
@@ -19,6 +19,7 @@ export type SelectSeasonProps = {
     label_name?: string;
     width?: number;
     disabled?: boolean;
+    start_year?: number;
 };
 export default function SelectSeasonDropDown({
     updateSeason,
@@ -26,6 +27,7 @@ export default function SelectSeasonDropDown({
     label_name,
     width,
     disabled,
+    start_year,
 }: SelectSeasonProps) {
     /**
      * @returns drop down menu with years ranging from 2017(year sleeper was launched) to current year
@@ -35,10 +37,9 @@ export default function SelectSeasonDropDown({
     const currentDate: Date = new Date();
     const currentYear = currentDate.getFullYear();
     const validYears = Array.from(
-        { length: currentYear - 2017 + 1 },
-        (_, i) => i + 2017
+        { length: currentYear - (start_year ? start_year : 2017) + 1 },
+        (_, i) => i + (start_year ? start_year : 2017)
     ).reverse();
-
     const handleSeasonChange = (event: SelectChangeEvent) => {
         //update season for component that called it
         updateSeason(event.target.value);

--- a/frontend/src/components/SelectSeasonDropDown.tsx
+++ b/frontend/src/components/SelectSeasonDropDown.tsx
@@ -44,9 +44,8 @@ export default function SelectSeasonDropDown({
         //update season for component that called it
         updateSeason(event.target.value);
     };
-    useEffect(() => {
-        updateSeason(selectedYear ? selectedYear : String(currentYear));
-    }, [selectedYear]);
+
+    updateSeason(selectedYear ? selectedYear : String(currentYear));
     return (
         <FormControl fullWidth disabled={disabled}>
             <InputLabel id="select-season-input-label">{label_name}</InputLabel>

--- a/frontend/src/feature/leagues/components/SleeperLeaguesHomePage.tsx
+++ b/frontend/src/feature/leagues/components/SleeperLeaguesHomePage.tsx
@@ -14,11 +14,14 @@ import {
   List,
   ListItem,
   ListItemText,
+  MenuItem,
   Paper,
+  Select,
   Tab,
   Tabs,
   Typography,
   useTheme,
+  type SelectChangeEvent,
 } from "@mui/material";
 import { useEffect, useState, type SyntheticEvent } from "react";
 import useGetLeagueTeamsSleeper from "@feature/leagues/hooks/useGetLeagueTeamsSleeper";
@@ -33,6 +36,7 @@ import useGetAllTransactionsType from "../hooks/useGetAllTransactions";
 import { ExpandMore } from "@mui/icons-material";
 import type { Transaction } from "@services/sleeper";
 import useGetPreviousSeasons from "../hooks/useGetPreviousSeasons";
+import { useNavigate } from "@tanstack/react-router";
 
 interface SleeperLeaguesHomePage {
   league_id: string;
@@ -459,13 +463,26 @@ const TransactionDisplay = ({ transactions }: { transactions: Record<number, Tra
 
 const PreviousSeasonsDropDown = ({ league_id }: { league_id: string; }) => {
   const { prevSeasons } = useGetPreviousSeasons(league_id);
-
-
+  const navigate = useNavigate();
   if (!prevSeasons || prevSeasons.length == 0) return null;
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
       <Typography >Previous Seasons</Typography>
-      <SelectSeasonDropDown selectedYear={prevSeasons.at(0)?.season ?? "2025"} start_year={Number(prevSeasons.at(-1)?.season)} updateSeason={() => { }} />
+      {/* <SelectSeasonDropDown selectedYear={prevSeasons.at(0)?.season ?? "2025"} start_year={Number(prevSeasons.at(-1)?.season)} updateSeason={(season:string) => {
+        navigate({to:`/leagues/${season}`})
+       }} /> */}
+      <Select
+        value={prevSeasons.at(0)?.league_id}
+        onChange={(event: SelectChangeEvent) => {
+          navigate({ to: `/leagues/${event.target.value}` });
+        }}
+      >
+        {prevSeasons.map((season) => {
+          return <MenuItem key={season.season} value={season.league_id}>
+            {season.season}
+          </MenuItem>;
+        })}
+      </Select>
     </Box>
   );
 };

--- a/frontend/src/feature/leagues/components/SleeperLeaguesHomePage.tsx
+++ b/frontend/src/feature/leagues/components/SleeperLeaguesHomePage.tsx
@@ -32,6 +32,7 @@ import SelectSeasonDropDown from "@components/SelectSeasonDropDown";
 import useGetAllTransactionsType from "../hooks/useGetAllTransactions";
 import { ExpandMore } from "@mui/icons-material";
 import type { Transaction } from "@services/sleeper";
+import useGetPreviousSeasons from "../hooks/useGetPreviousSeasons";
 
 interface SleeperLeaguesHomePage {
   league_id: string;
@@ -62,7 +63,7 @@ export default function SleeperLeaguesHomePage({
     useDelayedLoading([team_loading, roster_loading, loading], 1000);
 
   const { showError } = useNotification();
-  const { data: transactions, loading: transaction_loading, isError: transaction_error } = useGetAllTransactionsType(league_id)
+  const { data: transactions, loading: transaction_loading, isError: transaction_error } = useGetAllTransactionsType(league_id);
 
   useEffect(() => {
     if (error) {
@@ -187,10 +188,11 @@ export default function SleeperLeaguesHomePage({
               <Tab label="Transactions" {...a11yProps(1)} />
               <Tab label="Item Three" {...a11yProps(2)} />
             </Tabs>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-              <Typography >Season</Typography>
+            {/* <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <Typography >Previous Seasons</Typography>
               <SelectSeasonDropDown selectedYear="2025" updateSeason={() => { }} />
-            </Box>
+            </Box> */}
+            <PreviousSeasonsDropDown league_id={league_id} />
           </Box>
         </Box>
 
@@ -311,13 +313,13 @@ export default function SleeperLeaguesHomePage({
     </Box>
   );
 }
-const TransactionDisplay = ({ transactions }: { transactions: Record<number, Transaction[]> }) => {
+const TransactionDisplay = ({ transactions }: { transactions: Record<number, Transaction[]>; }) => {
   if (!transactions)
     return (
       <>
         No Transactions Found
       </>
-    )
+    );
 
 
   const getStatusColor = (status: string) => {
@@ -452,5 +454,18 @@ const TransactionDisplay = ({ transactions }: { transactions: Record<number, Tra
         </Paper>
       )}
     </Container>
+  );
+};
+
+const PreviousSeasonsDropDown = ({ league_id }: { league_id: string; }) => {
+  const { prevSeasons } = useGetPreviousSeasons(league_id);
+
+
+  if (!prevSeasons || prevSeasons.length == 0) return null;
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+      <Typography >Previous Seasons</Typography>
+      <SelectSeasonDropDown selectedYear={prevSeasons.at(0)?.season ?? "2025"} start_year={Number(prevSeasons.at(-1)?.season)} updateSeason={() => { }} />
+    </Box>
   );
 };


### PR DESCRIPTION
added ability to navigate to previous leagues in transactions tab.
need a way to keep track of parent/latest league such to allow the user to navigate back.