### PR TITLE
DM-98-League-Fix-initial-load-state

### DIFF
--- a/frontend/src/feature/leagues/components/SleeperLeaguesHomePage.tsx
+++ b/frontend/src/feature/leagues/components/SleeperLeaguesHomePage.tsx
@@ -62,7 +62,7 @@ export default function SleeperLeaguesHomePage({
     useDelayedLoading([team_loading, roster_loading, loading], 1000);
 
   const { showError } = useNotification();
-  const { data: transactions, loading: transaction_loading, isError: transaction_error } = useGetAllTransactionsType(league_id)
+  const { data: transactions, loading: transaction_loading, isError: transaction_error } = useGetAllTransactionsType(league_id);
 
   useEffect(() => {
     if (error) {
@@ -290,7 +290,7 @@ export default function SleeperLeaguesHomePage({
                     ))}
                   </Box>
                 )}
-                {!showRosterLoading && !roster && !roster_error && (
+                {roster && roster.length === 0 && (
                   <Typography
                     variant="body2"
                     color="text.secondary"
@@ -311,13 +311,13 @@ export default function SleeperLeaguesHomePage({
     </Box>
   );
 }
-const TransactionDisplay = ({ transactions }: { transactions: Record<number, Transaction[]> }) => {
+const TransactionDisplay = ({ transactions }: { transactions: Record<number, Transaction[]>; }) => {
   if (!transactions)
     return (
       <>
         No Transactions Found
       </>
-    )
+    );
 
 
   const getStatusColor = (status: string) => {

--- a/frontend/src/feature/leagues/hooks/useGetPlayersOnRosterSleeper.ts
+++ b/frontend/src/feature/leagues/hooks/useGetPlayersOnRosterSleeper.ts
@@ -26,6 +26,9 @@ export default function useGetPlayersOnRosterSleeper(league_id: string) {
                 setForceRefresh((prev) => prev + 1);
                 return prev;
             }
+
+            setPlayers(null);
+
             return owner_id;
         });
     };


### PR DESCRIPTION
The loading transition is still finicky due to the refreshRoster function, which sets players to null after each team selection change, but the "No roster unavailable" and displaying the previous roster initially are fixed.